### PR TITLE
debugging support in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/
 autom4te.cache/
 *~
-.vscode
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 output

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/.libs/cjpeg",
+            "args": ["bash", "cjpeg", "--help"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "environment": [{"name":"LD_LIBRARY_PATH", "value": "${workspaceFolder}/build/.libs"}],
+            "miDebuggerPath": "/usr/bin/gdb",
+            "preLaunchTask": "make cjpeg"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "make cjpeg",
+            "command": "/usr/bin/make",
+            "args": ["cjpeg", "-j8"],
+            "problemMatcher": [],
+			"options": {
+				"cwd": "${workspaceFolder}/build"
+			  }
+        }
+    ],
+    "version": "2.0.0"
+}


### PR DESCRIPTION
at this moment the cjpeg binary is run with the --help option. That should, of course, be changed as needed.